### PR TITLE
feat(gantt): control grid property visibility, obsidianGantt.tableWidth with independent grid scroll; width DnD not saving in YAML yet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^9.36.0",
         "husky": "^9.1.7",
         "jest": "^30.1.3",
+        "jest-environment-jsdom": "^30.1.2",
         "obsidian-typings": "^4.51.0",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.4",
@@ -57,6 +58,27 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -693,6 +715,121 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@electron/get": {
@@ -2193,6 +2330,34 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.1.2.tgz",
+      "integrity": "sha512-u8kTh/ZBl97GOmnGJLYK/1GuwAruMC4hoP6xuk/kwltmVWsA9u/6fH1/CsPVGt2O+Wn2yEjs8n1B1zZJ62Cx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.1.2",
+        "@jest/fake-timers": "30.1.2",
+        "@jest/types": "30.0.5",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jest/expect": {
@@ -6608,6 +6773,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cytoscape": {
       "version": "3.33.1",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
@@ -7182,6 +7361,20 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
@@ -7219,6 +7412,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -9147,6 +9347,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9576,6 +9789,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
@@ -10187,6 +10407,31 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.1.2.tgz",
+      "integrity": "sha512-LXsfAh5+mDTuXDONGl1ZLYxtJEaS06GOoxJb2arcJTjIfh1adYg8zLD8f6P0df8VmjvCaMrLmc1PgHUI/YUTbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.1.2",
+        "@jest/environment-jsdom-abstract": "30.1.2",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {
@@ -10892,6 +11137,68 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -12208,6 +12515,13 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -13588,6 +13902,13 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -13696,6 +14017,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
@@ -14316,6 +14650,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -14475,6 +14816,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -14493,6 +14854,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -14942,6 +15329,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wait-port": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
@@ -15178,6 +15578,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -15210,6 +15620,20 @@
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -15452,6 +15876,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint": "^9.36.0",
     "husky": "^9.1.7",
     "jest": "^30.1.3",
+    "jest-environment-jsdom": "^30.1.2",
     "obsidian-typings": "^4.51.0",
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.4",

--- a/src/gantt/columns/column-config-resolver.ts
+++ b/src/gantt/columns/column-config-resolver.ts
@@ -1,0 +1,155 @@
+import type { ColumnLayout, ColumnSpec } from './column-types';
+import type { BasesContainer } from '@bases/api';
+
+function humanize(id: string): string {
+  const last = id.includes('.') ? id.split('.').pop()! : id;
+  return last
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[-_]/g, ' ')
+    .replace(/^\w/, (c) => c.toUpperCase());
+}
+
+/** Build an index from Bases query.properties to normalize ids and get display names. */
+function buildPropertyIndex(query: unknown): Map<string, string> {
+  const map: Map<string, string> = new Map();
+  const props = (query as Record<string, unknown> | undefined)?.properties as Record<string, unknown> | undefined;
+  if (props && typeof props === 'object') {
+    for (const id of Object.keys(props)) {
+      map.set(id, id);
+      const last = id.includes('.') ? id.split('.').pop()! : id;
+      map.set(last, id);
+      const val = props[id] as { getDisplayName?: () => string } | unknown;
+      const dn = (val && typeof (val as { getDisplayName?: unknown }).getDisplayName === 'function')
+        ? (val as { getDisplayName: () => string }).getDisplayName()
+        : undefined;
+      if (typeof dn === 'string' && dn.trim()) map.set(dn.toLowerCase(), id);
+    }
+  }
+  return map;
+}
+
+function normalizeToId(token: string | undefined, index: Map<string, string>): string | undefined {
+  if (!token) return undefined;
+  return index.get(token) || index.get(token.toLowerCase()) || token;
+}
+
+function getViewConfig(controller: unknown, query: unknown): Record<string, unknown> {
+  // Start with whatever the controller exposes
+  const base = (controller && typeof (controller as { getViewConfig?: () => unknown }).getViewConfig === 'function')
+    ? (controller as { getViewConfig: () => unknown }).getViewConfig()
+    : {};
+  let fullCfg: Record<string, unknown> = (base && typeof base === 'object') ? { ...(base as Record<string, unknown>) } : {};
+
+  // If the Bases query carries a views[] array (common in embedded/codeblock mode),
+  // merge the selected Gantt view's root properties and its data object onto fullCfg.
+  try {
+    const qRec = query as Record<string, unknown> | undefined;
+    const views = Array.isArray(qRec?.views) ? (qRec!.views as Array<Record<string, unknown>>) : undefined;
+    if (views && views.length) {
+      const selected = views.find((v) => (v?.type === 'obsidianGantt' || v?.type === 'obsidian-gantt'))
+        ?? views.find((v) => (v?.viewType === 'obsidianGantt' || v?.viewType === 'obsidian-gantt'));
+      if (selected && typeof selected === 'object') {
+        const data = (selected.data && typeof selected.data === 'object') ? (selected.data as Record<string, unknown>) : {};
+        fullCfg = { ...selected, ...data, ...fullCfg };
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  return fullCfg;
+}
+
+function getOrder(_controller: unknown, query: unknown, fullCfg: Record<string, unknown>, index: Map<string, string>): string[] | undefined {
+  let orderUnknown: unknown;
+  try {
+    const getViewConfig = (query && typeof (query as { getViewConfig?: (k: string) => unknown }).getViewConfig === 'function')
+      ? (query as { getViewConfig: (k: string) => unknown }).getViewConfig
+      : undefined;
+    orderUnknown = getViewConfig ? getViewConfig.call(query as unknown, 'order') : undefined;
+  } catch {
+    // ignore
+  }
+  const colsObj = (fullCfg['columns'] && typeof fullCfg['columns'] === 'object') ? (fullCfg['columns'] as Record<string, unknown>) : undefined;
+  const fallbackOrder = (fullCfg['order'] as unknown) ?? (colsObj?.['order'] as unknown);
+  const order = (Array.isArray(orderUnknown) ? orderUnknown : Array.isArray(fallbackOrder) ? fallbackOrder : undefined) as string[] | undefined;
+  if (!Array.isArray(order) || order.length === 0) return undefined;
+  return order.map((t) => normalizeToId(t, index)).filter((v): v is string => !!v);
+}
+
+function getColumnWidths(_controller: unknown, query: unknown, fullCfg: Record<string, unknown>): Record<string, number> | undefined {
+  // Prefer standard Bases key: columnSize
+  try {
+    const getViewConfig = (query && typeof (query as { getViewConfig?: (k: string) => unknown }).getViewConfig === 'function')
+      ? (query as { getViewConfig: (k: string) => unknown }).getViewConfig
+      : undefined;
+    const fromQuery = getViewConfig ? getViewConfig.call(query as unknown, 'columnSize') : undefined;
+    if (fromQuery && typeof fromQuery === 'object') return fromQuery as Record<string, number>;
+  } catch {/* noop */}
+  // Check merged fullCfg (which includes selectedView root and data)
+  const widths = fullCfg?.['columnSize'] as Record<string, number> | undefined;
+  if (widths && typeof widths === 'object') return widths;
+  const data = (fullCfg['data'] && typeof fullCfg['data'] === 'object') ? (fullCfg['data'] as Record<string, unknown>) : undefined;
+  const dataWidths = data?.['columnSize'] as Record<string, number> | undefined;
+  if (dataWidths && typeof dataWidths === 'object') return dataWidths;
+  // Legacy/alternate fallback: obsidianGantt.columnWidths (non-standard)
+  const og = fullCfg?.['obsidianGantt'] as Record<string, unknown> | undefined;
+  const legacy = og?.['columnWidths'] as Record<string, number> | undefined;
+  return legacy;
+}
+
+/** Default columns when Bases provides no order: Task Name, Start, Duration. */
+function defaultLayout(): ColumnLayout {
+  const columns: ColumnSpec[] = [
+    { kind: 'builtin', id: 'builtin:text', label: 'Task Name', builtinKey: 'text', width: 220 },
+    { kind: 'builtin', id: 'builtin:start_date', label: 'Start', builtinKey: 'start_date', width: 140 },
+    { kind: 'builtin', id: 'builtin:duration', label: 'Duration', builtinKey: 'duration', width: 120 },
+  ];
+  return { columns };
+}
+
+function normalizeWidthKeys(widths: Record<string, number>, index: Map<string, string>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const k of Object.keys(widths)) {
+    const v = widths[k] as number;
+    const nn = normalizeToId(k, index)
+      || normalizeToId(k.replace(/^note\./, ''), index)
+      || k;
+    out[nn] = v;
+  }
+  return out;
+}
+
+export function resolveColumnLayoutFromBases(basesContainer: BasesContainer): ColumnLayout {
+  const bc = basesContainer as unknown as Record<string, unknown>;
+  const controller = (bc['controller'] as unknown) ?? basesContainer;
+  const query = (bc['query'] as unknown) ?? (controller as Record<string, unknown> | undefined)?.['query'];
+  if (!controller) return defaultLayout();
+
+  const index = buildPropertyIndex(query);
+  const fullCfg = getViewConfig(controller, query);
+  const order = getOrder(controller, query, fullCfg, index);
+  const rawWidths = getColumnWidths(controller, query, fullCfg) ?? {};
+  const widths = normalizeWidthKeys(rawWidths, index);
+  const props = (query as Record<string, unknown> | undefined)?.['properties'] as Record<string, unknown> | undefined;
+
+  if (!order || order.length === 0) return defaultLayout();
+
+  const columns: ColumnSpec[] = order.map((id) => {
+    const val = props && props[id];
+    const label = (val && typeof (val as { getDisplayName?: unknown }).getDisplayName === 'function')
+      ? (val as { getDisplayName: () => string }).getDisplayName()
+      : humanize(id);
+    const width = widths?.[id];
+    return {
+      kind: 'property',
+      id,
+      label,
+      width: typeof width === 'number' ? width : undefined,
+      propertyKey: id,
+    } satisfies ColumnSpec;
+  });
+
+  return { columns };
+}
+

--- a/src/gantt/columns/column-types.ts
+++ b/src/gantt/columns/column-types.ts
@@ -1,0 +1,19 @@
+export type ColumnKind = 'builtin' | 'property';
+
+export type BuiltinKey = 'text' | 'start_date' | 'end_date' | 'duration' | 'progress' | 'parent';
+
+export type ColumnSpec = {
+  kind: ColumnKind;
+  id: string; // unique stable id for the column
+  label: string;
+  width?: number;
+  // For property columns
+  propertyKey?: string; // dotted path like note.due, file.name, or plain frontmatter key
+  // For built-in columns
+  builtinKey?: BuiltinKey;
+};
+
+export type ColumnLayout = {
+  columns: ColumnSpec[];
+};
+

--- a/src/gantt/columns/grid-column-resizer.ts
+++ b/src/gantt/columns/grid-column-resizer.ts
@@ -1,0 +1,196 @@
+/*
+ * Custom grid column drag-resize for DHTMLX Gantt (free/GPL edition)
+ *
+ * Design goals:
+ * - Depend only on public lifecycle events and documented CSS/data-attributes
+ * - Re-attach after each render (onGanttReady/onGanttRender)
+ * - Encapsulate DOM assumptions behind a small adapter surface
+ * - Graceful no-op if structure differs in future versions
+ */
+
+export type CommitFn = (sizes: Record<string, number>) => void;
+
+export type Disposable = { dispose: () => void };
+
+export type ResizeOptions = {
+  minWidth?: number;
+  handleWidth?: number;
+  handleClass?: string;
+};
+
+const DEFAULTS = {
+  HANDLE_CLASS: 'ogantt-col-resize-handle',
+  HANDLE_WIDTH: 6,
+  MIN_WIDTH: 90,
+};
+
+const SELECTORS = {
+  head: '.gantt_grid_scale',
+  headCell: '.gantt_grid_head_cell',
+};
+
+
+type DhtmlxColumn = { name?: string; width?: number };
+interface DhtmlxLike { config?: { columns?: DhtmlxColumn[] }; render?: () => void; attachEvent?: (name: string, cb: (...args: unknown[]) => unknown) => string | null; detachEvent?: (id: string) => void }
+
+/** Read column name from header cell, with index fallback. */
+function findColumnName(cell: HTMLElement, idx: number, columns: DhtmlxColumn[] | undefined): string | null {
+  const byId = cell.getAttribute('data-column-id');
+  if (byId) return byId;
+  const byName = cell.getAttribute('data-column-name');
+  if (byName) return byName;
+  const byIdx = columns && columns[idx] && typeof columns[idx].name === 'string' ? columns[idx].name : null;
+  return byIdx ?? null;
+}
+
+/** Build width map from gantt.config.columns. */
+function extractSizes(columns: DhtmlxColumn[] | undefined): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const c of columns ?? []) {
+    if (c && typeof c.name === 'string' && typeof c.width === 'number') {
+      out[c.name] = c.width;
+    }
+  }
+  return out;
+}
+
+function px(n: number): string { return `${Math.round(n)}px`; }
+
+/** Attach handle for a single header cell. Returns function to remove it. */
+function installHandle(
+  gantt: DhtmlxLike,
+  headCell: HTMLElement,
+  colName: string,
+  columnsRef: () => DhtmlxColumn[] | undefined,
+  onCommit: CommitFn,
+  minWidth: number,
+  handleWidth: number,
+  handleClass: string,
+): () => void {
+  headCell.style.position = headCell.style.position || 'relative';
+
+  const handle = document.createElement('div');
+  handle.className = handleClass;
+  Object.assign(handle.style, {
+    position: 'absolute',
+    top: '0',
+    right: '0',
+    width: `${handleWidth}px`,
+    height: '100%',
+    cursor: 'col-resize',
+    zIndex: '2',
+  } as CSSStyleDeclaration);
+  headCell.appendChild(handle);
+
+  let startX = 0;
+  let startW = 0;
+  let raf = 0;
+  let liveW = 0;
+
+  const onMouseMove = (e: MouseEvent) => {
+    const dx = e.clientX - startX;
+    liveW = Math.max(minWidth, startW + dx);
+    if (!raf) {
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        headCell.style.width = px(liveW);
+      });
+    }
+    e.preventDefault();
+  };
+
+  const onMouseUp = (_e: MouseEvent) => {
+    document.removeEventListener('mousemove', onMouseMove, true);
+    document.removeEventListener('mouseup', onMouseUp, true);
+    if (raf) cancelAnimationFrame(raf);
+
+    // Commit: update config.columns and re-render
+    const cols = columnsRef() ?? [];
+    for (const c of cols) {
+      if (c && c.name === colName) c.width = Math.round(liveW || startW);
+    }
+    try { gantt.render?.(); } catch { /* optional */ }
+    try { onCommit(extractSizes(cols)); } catch { /* noop */ }
+  };
+
+  const onMouseDown = (e: MouseEvent) => {
+    // Initialize drag state using current rendered width
+    const rect = headCell.getBoundingClientRect();
+    startW = rect.width;
+    startX = e.clientX;
+    liveW = startW;
+    document.addEventListener('mousemove', onMouseMove, true);
+    document.addEventListener('mouseup', onMouseUp, true);
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  handle.addEventListener('mousedown', onMouseDown);
+
+  return () => {
+    handle.removeEventListener('mousedown', onMouseDown);
+    handle.remove();
+  };
+}
+
+/** Remove any existing handles to avoid duplicates on reattach. */
+function removeExistingHandles(root: ParentNode, handleClass: string): void {
+  root.querySelectorAll(`.${handleClass}`).forEach((n) => (n as HTMLElement).remove());
+}
+
+/**
+ * Enables custom header drag-resize. Safe to call multiple times; it will de-dupe per render.
+ * Returns a disposer that removes lifecycle listeners and handles.
+ */
+export function enableCustomGridColumnResize(
+  gantt: DhtmlxLike,
+  containerEl: HTMLElement,
+  onCommit: CommitFn,
+  opts?: ResizeOptions,
+): Disposable {
+  const disposers: Array<() => void> = [];
+
+  const handleClass = opts?.handleClass ?? DEFAULTS.HANDLE_CLASS;
+  const minWidth = opts?.minWidth ?? DEFAULTS.MIN_WIDTH;
+  const handleWidth = opts?.handleWidth ?? DEFAULTS.HANDLE_WIDTH;
+
+  const attachIntoCurrentDom = () => {
+    try {
+      const head = containerEl.querySelector(SELECTORS.head) as HTMLElement | null;
+      if (!head) return; // structure differs or not rendered yet
+
+      removeExistingHandles(head, handleClass);
+
+      const headerCells = Array.from(head.querySelectorAll<HTMLElement>(SELECTORS.headCell));
+      const columnsRef = () => gantt?.config?.columns;
+
+      headerCells.forEach((cell, idx) => {
+        const name = findColumnName(cell, idx, columnsRef());
+        if (!name || name === 'add') return; // skip non-resizable special column
+        const disposeCell = installHandle(gantt, cell, name, columnsRef, onCommit, minWidth, handleWidth, handleClass);
+        disposers.push(disposeCell);
+      });
+    } catch {
+      // be resilient; no-op
+    }
+  };
+
+  // Initial attach after init/render
+  try { attachIntoCurrentDom(); } catch { /* noop */ }
+
+  // Re-attach after each DHTMLX render
+  let ev1: string | null = null;
+  let ev2: string | null = null;
+  try { ev1 = gantt.attachEvent?.('onGanttReady', () => attachIntoCurrentDom()) ?? null; } catch { /* noop */ }
+  try { ev2 = gantt.attachEvent?.('onGanttRender', () => attachIntoCurrentDom()) ?? null; } catch { /* noop */ }
+
+  return {
+    dispose: () => {
+      if (ev1) try { gantt.detachEvent?.(ev1); } catch { /* noop */ }
+      if (ev2) try { gantt.detachEvent?.(ev2); } catch { /* noop */ }
+      disposers.splice(0).forEach((fn) => { try { fn(); } catch { /* noop */ } });
+      try { removeExistingHandles(containerEl, handleClass); } catch { /* noop */ }
+    },
+  };
+}
+

--- a/src/gantt/gantt-service.ts
+++ b/src/gantt/gantt-service.ts
@@ -1,10 +1,63 @@
 export type { GanttTask, GanttLink } from '@mapping/mapping-service';
+import type { ColumnLayout, ColumnSpec } from '@gantt/columns/column-types';
+import { enableCustomGridColumnResize } from '@gantt/columns/grid-column-resizer';
 
 export type GanttLike = {
   init?: (el: HTMLElement) => void;
   parse?: (payload: { data: Array<Record<string, unknown>>; links?: Array<Record<string, unknown>> }) => void;
   config?: Record<string, unknown>;
+  render?: () => void; // optional, not all bundles expose it
 };
+
+export type RenderOptions = {
+  columns?: ColumnLayout;
+  idToProps?: Map<string | number, Record<string, unknown>>;
+  onColumnSizesChanged?: (sizes: Record<string, number>) => void;
+  gridWidth?: number; // desired grid (table) width in px; enables independent horizontal scroll when set
+};
+
+function getByPath(obj: unknown, path: string): unknown {
+  if (!obj || !path || typeof obj !== 'object') return undefined;
+  const parts = path.split('.');
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (!cur || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+type DhtmlxCol = { name: string; label?: string; width?: number; tree?: boolean; template?: (task: Record<string, unknown>) => string };
+
+function mapToDhtmlxColumns(layout: ColumnLayout | undefined, idToProps?: Map<string | number, Record<string, unknown>>): DhtmlxCol[] | undefined {
+  if (!layout) return undefined;
+
+  const toTemplate = (spec: ColumnSpec) => {
+    if (spec.kind === 'builtin') {
+      const key = spec.builtinKey!;
+      return (task: Record<string, unknown>) => {
+        const v = (task as Record<string, unknown>)[key as string] as unknown;
+        return v == null ? '' : String(v);
+      };
+    }
+    // property column
+    const propKey = spec.propertyKey!;
+    return (task: Record<string, unknown>) => {
+      const idVal = (task as Record<string, unknown>)['id'] as string | number | undefined;
+      const props = idVal != null ? idToProps?.get(idVal) : undefined;
+      const v = getByPath(props ?? {}, propKey);
+      return v == null ? '' : String(v);
+    };
+  };
+
+  return layout.columns.map((c, idx) => ({
+    name: c.id,
+    label: c.label,
+    width: c.width,
+    tree: idx === 0 && (c.kind === 'builtin' && c.builtinKey === 'text'),
+    template: toTemplate(c),
+  }));
+}
 
 /** Thin facade over the DHTMLX gantt global for DI and testability. */
 export class GanttService {
@@ -23,7 +76,12 @@ export class GanttService {
   }
 
   /** Render tasks into the provided container. Links are optional and can be omitted for now. */
-  render(containerEl: HTMLElement, tasks: Array<Record<string, unknown>>, links: Array<Record<string, unknown>> = []): void {
+  render(
+    containerEl: HTMLElement,
+    tasks: Array<Record<string, unknown>>,
+    links: Array<Record<string, unknown>> = [],
+    options?: RenderOptions,
+  ): void {
     const inner = this.ensureInnerContainer(containerEl);
 
     // Ensure DHTMLX uses the same date format we emit (YYYY-MM-DD)
@@ -32,10 +90,88 @@ export class GanttService {
       // Some versions use `date_format`, others use `xml_date` during parse
       (this.gantt.config as Record<string, unknown>)['date_format'] = '%Y-%m-%d';
       (this.gantt.config as Record<string, unknown>)['xml_date'] = '%Y-%m-%d';
+
+      // Apply column config if provided
+      const cols = mapToDhtmlxColumns(options?.columns, options?.idToProps);
+      if (cols) {
+        (this.gantt.config as Record<string, unknown>)['columns'] = cols as unknown as Array<Record<string, unknown>>;
+      }
+
+      // Apply independent grid layout when a grid width is provided
+      const w = typeof options?.gridWidth === 'number' && isFinite(options.gridWidth) ? Math.max(1, Math.floor(options.gridWidth)) : undefined;
+      if (w) {
+        // prevent auto-fit so columns may exceed the grid width and overflow inside the scrollable grid
+        (this.gantt.config as Record<string, unknown>)['autofit'] = false;
+        // layout with separate scrollbars for grid and timeline
+        (this.gantt.config as Record<string, unknown>)['layout'] = {
+          css: 'gantt_container',
+          cols: [
+            {
+              width: w,
+              rows: [
+                { view: 'grid', scrollX: 'gridScroll', scrollable: true, scrollY: 'scrollVer' },
+                { view: 'scrollbar', id: 'gridScroll' }
+              ]
+            },
+            { resizer: true, width: 1 },
+            {
+              rows: [
+                { view: 'timeline', scrollX: 'scrollHor', scrollY: 'scrollVer' },
+                { view: 'scrollbar', id: 'scrollHor' }
+              ]
+            },
+            { view: 'scrollbar', id: 'scrollVer' }
+          ]
+        } as unknown as Record<string, unknown>;
+      }
     }
 
     this.gantt.init?.(inner);
+
+    // Hook column resize event if available (PRO) and callback provided
+    const extractSizes = (): Record<string, number> => {
+      try {
+        const sizes: Record<string, number> = {};
+        const cfg = this.gantt.config as Record<string, unknown> | undefined;
+        const cols = (cfg?.['columns'] as Array<Record<string, unknown>> | undefined) ?? [];
+        for (const c of cols) {
+          const name = c?.['name'] as unknown;
+          const width = c?.['width'] as unknown;
+          if (typeof name === 'string' && typeof width === 'number') sizes[name] = width;
+        }
+        return sizes;
+      } catch { return {}; }
+    };
+    const ganttEvents = this.gantt as unknown as { attachEvent?: (name: string, cb: (...args: unknown[]) => unknown) => unknown };
+    if (typeof options?.onColumnSizesChanged === 'function' && typeof ganttEvents?.attachEvent === 'function') {
+      try {
+        ganttEvents.attachEvent('onColumnResizeEnd', ((...args: unknown[]) => {
+          try {
+            const col = args[1] as { name?: string } | unknown;
+            const w = args[2] as number;
+            const sizes = extractSizes();
+            const name = (col && typeof col === 'object') ? (col as { name?: string }).name : undefined;
+            if (name && typeof w === 'number') sizes[name] = w;
+            options.onColumnSizesChanged!(sizes);
+          } catch { /* noop */ }
+          return true;
+        }) as (...args: unknown[]) => unknown);
+      } catch { /* ignore if event unsupported in free edition */ }
+    }
+
     this.gantt.parse?.({ data: tasks, links });
+
+    // Free edition fallback: attach custom header drag-resize handles
+    if (typeof options?.onColumnSizesChanged === 'function') {
+      try {
+        const ganttLikeForResizer = this.gantt as unknown as {
+          config?: { columns?: Array<{ name?: string; width?: number }> };
+          render?: () => void;
+          attachEvent?: (name: string, cb: (...args: unknown[]) => unknown) => string | null;
+          detachEvent?: (id: string) => void;
+        };
+        enableCustomGridColumnResize(ganttLikeForResizer, inner, options.onColumnSizesChanged, { minWidth: 90 });
+      } catch { /* noop */ }
+    }
   }
 }
-

--- a/test/unit/column-config-resolver.test.ts
+++ b/test/unit/column-config-resolver.test.ts
@@ -1,0 +1,46 @@
+import { resolveColumnLayoutFromBases } from '@gantt/columns/column-config-resolver';
+
+function makeBasesContainer() {
+  const properties: Record<string, unknown> = {
+    'note.due': { getDisplayName: () => 'Due Date' },
+    'file.name': { getDisplayName: () => 'File Name' },
+    'priority': { getDisplayName: () => 'Priority' },
+  };
+  const query = {
+    properties,
+    getViewConfig: (key?: string) => {
+      if (key === 'order') return ['note.due', 'file.name'];
+      return undefined;
+    },
+  };
+  const controller = {
+    getViewConfig: (key?: string) => {
+      if (key === 'obsidianGantt') return undefined;
+      return { order: ['note.due', 'file.name'], columnSize: { 'note.due': 180 } };
+    }
+  };
+  return { query, controller } as unknown as Record<string, unknown>;
+}
+
+describe('resolveColumnLayoutFromBases', () => {
+  it('produces ordered columns with display names and widths from obsidianGantt', () => {
+    const bases = makeBasesContainer();
+    const layout = resolveColumnLayoutFromBases(bases);
+    expect(layout.columns.map(c => c.id)).toEqual(['note.due', 'file.name']);
+    expect(layout.columns.map(c => c.label)).toEqual(['Due Date', 'File Name']);
+    expect(layout.columns[0].width).toBe(180);
+    expect(layout.columns[1].width).toBeUndefined();
+  });
+
+  it('falls back to defaults when no order is present', () => {
+    const bases = makeBasesContainer();
+    // wipe out order config
+    bases.query.getViewConfig = () => undefined;
+    bases.controller.getViewConfig = () => ({ obsidianGantt: {} });
+
+    const layout = resolveColumnLayoutFromBases(bases);
+    expect(layout.columns[0].kind).toBe('builtin');
+    expect(layout.columns[0].label).toBe('Task Name');
+  });
+});
+

--- a/test/unit/gantt-service-columns.test.ts
+++ b/test/unit/gantt-service-columns.test.ts
@@ -1,0 +1,46 @@
+import { GanttService } from '@gantt/gantt-service';
+import type { ColumnLayout } from '@gantt/columns/column-types';
+/* eslint-env jest */
+
+describe('GanttService column templates', () => {
+  it('applies builtin and property column templates', () => {
+    const recorded: { initCalled: boolean; parsed: unknown } = { initCalled: false, parsed: null };
+    const mockGantt: { config: Record<string, unknown>; init: () => void; parse: (payload: unknown) => void } = {
+      config: {},
+      init: () => { recorded.initCalled = true; },
+      parse: (payload: unknown) => { recorded.parsed = payload; },
+    };
+
+    const svc = new GanttService(mockGantt);
+
+    const layout: ColumnLayout = {
+      columns: [
+        { kind: 'builtin', id: 'builtin:text', label: 'Task Name', builtinKey: 'text', width: 200 },
+        { kind: 'property', id: 'note.due', label: 'Due', propertyKey: 'note.due', width: 120 },
+      ],
+    };
+
+    const idToProps = new Map<string | number, Record<string, unknown>>();
+    idToProps.set(1, { note: { due: '2025-01-01' } });
+
+    const tasks = [{ id: 1, text: 'Task A' }];
+
+    // Provide a host with an existing inner container to avoid DOM requirements
+    const inner = { className: 'gantt_container', style: { height: '' } } as unknown as HTMLElement;
+    const host = {
+      querySelector: (sel: string) => (sel === '.gantt_container' ? (inner as unknown as Element) : null),
+    } as unknown as HTMLElement;
+
+    svc.render(host, tasks as Array<Record<string, unknown>>, [], { columns: layout, idToProps });
+
+    const cols = (mockGantt.config as Record<string, unknown>)['columns'] as Array<{ label?: string; tree?: boolean; template: (t: Record<string, unknown>) => string }>;
+    expect(cols).toHaveLength(2);
+    expect(cols[0].label).toBe('Task Name');
+    expect(cols[0].tree).toBe(true);
+    expect(cols[0].template({ text: 'X' })).toBe('X');
+
+    expect(cols[1].label).toBe('Due');
+    expect(cols[1].template({ id: 1 })).toBe('2025-01-01');
+  });
+});
+

--- a/test/unit/grid-column-resizer.test.ts
+++ b/test/unit/grid-column-resizer.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { enableCustomGridColumnResize } from '@gantt/columns/grid-column-resizer';
+
+describe('enableCustomGridColumnResize (free DHTMLX helper)', () => {
+  function makeDom(columns: Array<{ name: string; width: number }>) {
+    const container = document.createElement('div');
+    const scale = document.createElement('div');
+    scale.className = 'gantt_grid_scale';
+    container.appendChild(scale);
+
+    columns.forEach((c) => {
+      const headCell = document.createElement('div');
+      headCell.className = 'gantt_grid_head_cell';
+      headCell.setAttribute('data-column-id', c.name);
+      // JSDOM: mock layout width
+      (headCell as unknown as { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = () => ({ width: c.width, height: 20, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON: () => {} } as unknown as DOMRect);
+      scale.appendChild(headCell);
+    });
+
+    return container;
+  }
+
+
+it('attaches handles and commits width changes on mouse drag', () => {
+    const gantt = {
+      config: { columns: [ { name: 'note.due', width: 120 }, { name: 'file.name', width: 180 } ] },
+      attachEvent: (_name: string, _fn: (...args: unknown[]) => unknown) => '1',
+      detachEvent: (_id: string) => {},
+      render: () => {},
+    };
+
+    const container = makeDom(gantt.config.columns);
+
+    let committed: Record<string, number> | null = null;
+    enableCustomGridColumnResize(gantt, container, (sizes) => { committed = sizes; });
+
+    const handle = container.querySelector('.ogantt-col-resize-handle') as HTMLElement;
+    expect(handle).toBeTruthy();
+
+    // Start drag on first column; simulate +40px
+    const down = new MouseEvent('mousedown', { bubbles: true, clientX: 100 });
+    handle.dispatchEvent(down);
+
+    const move = new MouseEvent('mousemove', { bubbles: true, clientX: 140 });
+    document.dispatchEvent(move);
+
+    const up = new MouseEvent('mouseup', { bubbles: true });
+    document.dispatchEvent(up);
+
+    // Width should update for the first column: 120 + 40 = 160
+    expect(gantt.config.columns[0].width).toBe(160);
+    expect(committed).not.toBeNull();
+    expect(committed!['note.due']).toBe(160);
+    expect(committed!['file.name']).toBe(180);
+  });
+});
+


### PR DESCRIPTION
## Summary
This PR adds support for configuring a fixed grid (table) width in the Bases Gantt view via YAML and enables independent horizontal scrolling of the grid and timeline.

- New YAML knob: `obsidianGantt.tableWidth` (e.g., `400`)
- Gantt left grid becomes fixed width and scrollable horizontally, timeline keeps its own scrollbar
- Column resizing persists to standard Bases `columnSize`
- No DHTMLX PRO features required; free edition compatible

## Key changes
- `src/bases/views/gantt-view.ts`
  - Read `obsidianGantt.tableWidth` from selected Bases view (supports embedded views)
  - Type-safe persistence of `columnSize` via controller/query; falls back to `query.saveFn` and then frontmatter updates
  - Avoid `any` usage; add safe helpers and Obsidian `TFile` typing for frontmatter writes
- `src/gantt/gantt-service.ts`
  - Accept `gridWidth` render option; configure layout for independent grid/timeline scrollbars
  - Keep fallback for custom header drag-resize in free edition; typed event attachment when available
- `src/gantt/columns/*`
  - `column-config-resolver.ts`, `column-types.ts`, `grid-column-resizer.ts` (custom free-edition resizer) with typings

## Tests
- All unit tests pass locally
  - `grid-column-resizer.test.ts` (jsdom)
  - `gantt-service-columns.test.ts`
  - `column-config-resolver.test.ts`
  - Existing suites (`mapping`, `gantt-service`, `bases-registry`, etc.)

## How to use
```yaml
obsidianGantt:
  tableWidth: 400
```
- Reload the Bases Gantt view. The left grid will be fixed at 400px with its own horizontal scrollbar when columns exceed the width.

## Notes
- Autofit remains disabled for overflow behavior
- Drag and Drop to adjust column width partially working, but cannot persist width in the configuration