### PR TITLE
CI: avoid duplicate checks by scoping triggers to PRs and pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates the CI trigger configuration to avoid duplicate runs on PRs:

- on: pull_request remains
- on: push is now limited to main only

Outcome
- For feature branches with open PRs, only pull_request checks will run (no duplicate push checks)
- Pushes to main (post-merge) will still run CI

No code changes, YAML only.